### PR TITLE
[SPARK-21549][Master] Fix failure when "mapreduce.output.fileoutputformat.outputdir" is not set

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -193,11 +193,15 @@ class HadoopMapRedWriteConfigUtil[K, V: ClassTag](conf: SerializableJobConf)
   override def createCommitter(jobId: Int): HadoopMapReduceCommitProtocol = {
     // Update JobConf.
     HadoopRDD.addLocalConfiguration("", 0, 0, 0, getConf)
+    var path = getConf.get("mapred.output.dir")
+    if (path == null) {
+      path = Utils.createTempDir().getPath + "/mapred-output-dir"
+    }
     // Create commit protocol.
     FileCommitProtocol.instantiate(
       className = classOf[HadoopMapRedCommitProtocol].getName,
       jobId = jobId.toString,
-      outputPath = getConf.get("mapred.output.dir")
+      outputPath = path
     ).asInstanceOf[HadoopMapReduceCommitProtocol]
   }
 
@@ -322,10 +326,14 @@ class HadoopMapReduceWriteConfigUtil[K, V: ClassTag](conf: SerializableConfigura
   // --------------------------------------------------------------------------
 
   override def createCommitter(jobId: Int): HadoopMapReduceCommitProtocol = {
+    var path = getConf.get("mapreduce.output.fileoutputformat.outputdir")
+    if (path == null) {
+      path = Utils.createTempDir().getPath + "/mapreduce-output-dir"
+    }
     FileCommitProtocol.instantiate(
       className = classOf[HadoopMapReduceCommitProtocol].getName,
       jobId = jobId.toString,
-      outputPath = getConf.get("mapreduce.output.fileoutputformat.outputdir")
+      outputPath = path
     ).asInstanceOf[HadoopMapReduceCommitProtocol]
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Issue**:
Some OutputFormat implementations which do not need to use `"mapreduce.output.fileoutputformat.outputdir"` hadoop property, e.g. HBase's `TableOutputFormat`. 

When `saveAsNewAPIHadoopDataset()` is invoked to save data into HBase:
saveAsNewAPIHadoopDataset -> SparkHadoopWriter.write() -> [createCommitter()](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala#L328 ) -> `outputPath = getConf.get("mapreduce.output.fileoutputformat.outputdir") = null`, then the field `path` in `HadoopMapReduceCommitProtocol` will be null, that will throw `"IllegalArgumentException: Can not create a Path from a null string".`

The PR is to make OutputFormat implementation like `TableOutputFormat` work with Spark. 

## How was this patch tested?
Pass build and current tests.

